### PR TITLE
Check permissions unix-way

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -142,9 +142,7 @@ class TrainingActivity(activity.Activity):
             alert.connect('response', self._remove_alert_cb)
             self.add_alert(alert)
             self._load_intro_graphics()
-        elif not tests.is_writeable(os.path.join(
-                self.volume_data[0]['usb_path'],
-                self.volume_data[0]['uid'])):
+        elif not tests.is_writeable(self.volume_data[0]['usb_path']):
             _logger.error('CANNOT WRITE TO USB')
             alert = ConfirmationAlert()
             alert.props.title = _('Cannot write to USB')


### PR DESCRIPTION
Check if path write flags are enabled for the current
user, group or everyone else.

The permission logic was failing during the "first time"
scenario, where the activity was opened for the first time,
because there was no data file to read from in the first
place.

This patch solves the logic and also does proper permission
checking.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
