### PR TITLE
Use Zendesk custom fields

### DIFF
--- a/helppanel.py
+++ b/helppanel.py
@@ -27,7 +27,7 @@ from sugar3.graphics.radiotoolbutton import RadioToolButton
 from activity import NAME_UID, EMAIL_UID, SCHOOL_UID
 import utils
 
-from soupdesk import Attachment, Ticket, ZendeskError
+from soupdesk import Attachment, Ticket, FieldHelper, ZendeskError
 
 import logging
 _logger = logging.getLogger('training-activity-help')
@@ -183,12 +183,14 @@ class HelpPanel(Gtk.Grid):
 
     def _do_send(self, data):
         subject = data['ticket']
-
         body = data['body']
-        body += '\n\nsection: %s' % data['section']
-        body += '\ntask: %s' % str(data['task'])
-        if data['school'] is not None:
-            body += '\nschool: %s' % data['school']
+
+        helper = FieldHelper()
+        fields = []
+        fields.append(helper.get_field(0, data['section']))
+        fields.append(helper.get_field(1, data['task']))
+        if 'school' in data:
+            fields.append(helper.get_field(2, data['school']))
 
         uploads = []
         if 'screenshot' in data:
@@ -201,7 +203,10 @@ class HelpPanel(Gtk.Grid):
             uploads.append(attachment.token())
 
         ticket = Ticket()
-        ticket.create(subject, body, uploads, data['name'], data['email'])
+        ticket.create(subject, body,
+                      uploads,
+                      data['name'], data['email'],
+                      fields)
 
     def _take_screen_shot_and_send(self):
         bounds = self._text_buffer.get_bounds()

--- a/soupdesk.py
+++ b/soupdesk.py
@@ -19,6 +19,25 @@ class ZendeskError(Exception):
     pass
 
 
+class FieldHelper(object):
+
+    IDS = '/desktop/sugar/services/zendesk/fields'
+
+    def __init__(self):
+        # FIXME #3926 Gconf get_list is missing
+        client = GConf.Client.get_default()
+        raw = client.get(self.IDS)
+        if not raw:
+            raise ZendeskError('soupdesk is missing fields')
+        self._ids = [e.get_int() for e in raw.get_list()]
+
+    def get_field(self, index, value):
+        field = {}
+        field['id'] = self._ids[index]
+        field['value'] = value
+        return field
+
+
 class Request(object):
 
     URL = '/desktop/sugar/services/zendesk/url'
@@ -64,7 +83,7 @@ class Ticket(Request):
     def _endpoint(self):
         return '%s%s' % (self._url, self.RESOURCE)
 
-    def create(self, subject, body, uploads, name, email):
+    def create(self, subject, body, uploads, name, email, fields):
         ticket = {}
         ticket['subject'] = subject
         ticket['comment'] = {}
@@ -75,6 +94,8 @@ class Ticket(Request):
             ticket['requester'] = {}
             ticket['requester']['name'] = name
             ticket['requester']['email'] = email
+        if fields:
+            ticket['custom_fields'] = fields
         data = json.dumps({'ticket': ticket})
         self._request('POST', self._endpoint(), data, self.CONTENT)
 


### PR DESCRIPTION
Instead of appending metadata to the ticket description,
use the server side custom fields.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
