### PR TITLE
Prepare for activities.sugarlabs.org

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -1,9 +1,9 @@
 [Activity]
 name = Sugar Labs Academy
 exec = sugar-activity activity.TrainingActivity
-bundle_id = org.sugarlabs.Training
+bundle_id = org.sugarlabs.SugarTraining
 icon = sugar-labs-academy
-activity_version = 3.6
+activity_version = 1.0
 show_launcher = yes
 license = GPLv3
 single_instance = yes

--- a/schools.txt
+++ b/schools.txt
@@ -4914,7 +4914,7 @@
 0019000000EVz4t,Olivet Christian College,,89 Main Rd,Campbells Creek,VIC,3451
 0019000000EW0Kw,Omeo Primary School,,167 Day Ave,Omeo,VIC,3898
 0019000000EVzBA,One Arm Point Remote Community School,,One Arm Point Community via,Broome,WA,6725
-0019000000pETbT,One Education School,Level 1, 93 Bathurst St,Sydney,NSW,1111
+0019000000pETbT,Sugar Labs School,Level 1,137 MONTAGUE ST STE 380,Brooklyn,NY,1111
 0019000000EW0XW,One Mile State School,,7 John St,Gympie,QLD,4570
 0019000000EW0jA,One Tree Hill Primary School,,McGilp Rd,One Tree Hill,SA,5114
 0019000000EW0sK,Ongerup Primary School,,Carpenter St,Ongerup,WA,6336

--- a/tasks.py
+++ b/tasks.py
@@ -1030,8 +1030,8 @@ class Connected6Task(HTMLTask):
                         school.split(',')
                 except:
                     _logger.debug('bad school data? (%s)' % school)
-                # save the SF_ID from One Education in case we need it
-                if name == 'One Education School':
+                # save the SF_ID from Sugar Labs in case we need it
+                if name == 'Sugar Labs School':
                     self._default_sf_id = sf_id
                 try:
                     if int(postal_code) != self._postal_code:


### PR DESCRIPTION
A few changes to make the activity prepped for distribution through ASLO:
(1) change the bundle ID to make it differ from the one used by One Academy
(2) change the version number to 1.0
(3) change the default school name to Sugar Labs Academy
